### PR TITLE
Add feature to import task models from JSON config files

### DIFF
--- a/Examples/tasks.json
+++ b/Examples/tasks.json
@@ -1,0 +1,19 @@
+{
+    "t0": {
+        "id": 0,
+        "deadline": 4,
+        "wcet": 2,
+        "dependencies": ["t2"]
+    },
+
+    "t1": {
+        "id": 1,
+        "wcet": 3
+    },
+
+    "t2": {
+        "id": 2,
+        "release": 1,
+        "wcet": 1
+    }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "1ccfa8e20d2b782adb9ab2670c9ecce30ad8d978",
           "version": "2.0.0"
         }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "8d31a0905c346a45c87773ad50862b5b3df8dff6",
+          "version": "0.0.4"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,13 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/kyouko-taiga/DDKit.git", from: "2.0.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.0.1"),
   ],
   targets: [
-    .target(name: "schedulability", dependencies: ["SchedulabilityLib"]),
+    .target(name: "schedulability", dependencies: [
+      "SchedulabilityLib",
+      .product(name: "ArgumentParser", package: "swift-argument-parser"),
+    ]),
     .target(name: "SchedulabilityLib", dependencies: ["DDKit"]),
     .testTarget(name: "SchedulabilityLibTests", dependencies: ["SchedulabilityLib"]),
   ])

--- a/Sources/SchedulabilityLib/TaskModel+JSON.swift
+++ b/Sources/SchedulabilityLib/TaskModel+JSON.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+struct RuntimeError: Error, CustomStringConvertible {
+  var description: String
+  
+  init(_ description: String) {
+    self.description = description
+  }
+}
+
+/// An error thrown when the JSON data used to initialize a TaskModel is invalid, incomplete, or
+/// contains a circular dependency between tasks.
+enum SerializationError: Error, CustomStringConvertible {
+
+  case invalidConfiguration
+  case missing(task: String, field: String)
+  case invalid(task: String, field: String)
+  case circularDependency(task1: String, task2: String)
+  
+  var description: String {
+    switch self {
+    case .invalidConfiguration:
+      return "Input configuration file does not follow a valid format"
+    case .missing(let taskName, let fieldName):
+      return "Task '\(taskName)' is missing field '\(fieldName)'"
+    case .invalid(let taskName, let fieldName):
+      return "Field '\(fieldName)' of task '\(taskName)' is invalid"
+    case .circularDependency(let taskName1, let taskName2):
+      return "Found circular dependency between '\(taskName1)' and '\(taskName2)'"
+    }
+  }
+
+}
+
+extension TaskModel {
+  
+  /// Initialize a task model from a JSON configuration file.
+  ///
+  /// - Parameter json: The path to a JSON file containing a desciption of the task model to
+  ///     initialize.
+  public init(from json: String) throws {
+    // Throw a runtime error if the input JSON file cannot be read.
+    guard let input = try? Data(contentsOf: URL(fileURLWithPath: json), options: []) else {
+      throw RuntimeError("Couldn't read from '\(json)'!")
+    }
+    
+    // Read the configuration file as a dictionary.
+    guard let jsonData = try JSONSerialization.jsonObject(with: input, options: [])
+      as? [String: [String: Any]] else {
+        throw SerializationError.invalidConfiguration
+    }
+    
+    func buildTask(
+      name: String,
+      data: [String: Any],
+      tasks: inout [String: Task],
+      dependedOnBy: Set<String> = []
+    ) throws {
+      // Return if the current task has already been built previously (for example as a dependency
+      // for another task).
+      if tasks[name] != nil {
+        return
+      }
+      
+      // The 'id' field is compulsory for all tasks.
+      guard let id = data["id"] as? Int else {
+        throw SerializationError.missing(task: name, field: "id")
+      }
+      
+      // So is 'wcet'.
+      guard let wcet = data["wcet"] as? Int else {
+        throw SerializationError.missing(task: name, field: "wcet")
+      }
+      
+      let release = data["release"] as? Int ?? 0
+      let deadline = data["deadline"] as? Int
+      
+      // Build all of the dependencies of the current task.
+      let dependencyNames = data["dependencies"] as? [String] ?? []
+      var dependencies: Set<Task> = []
+      
+      // The current task is added as a depending task for all of its dependencies.
+      var newDependedOnBy = dependedOnBy
+      newDependedOnBy.insert(name)
+      
+      for dependency in dependencyNames {
+        // If one of the tasks the current task depends on is among its dependencies, we have a
+        // circular dependency and throw an error.
+        if dependedOnBy.contains(dependency) {
+          throw SerializationError.circularDependency(task1: name, task2: dependency)
+        }
+        
+        // Check that the dependencies of the current task are all defined in the configuration
+        // file.
+        if jsonData[dependency] == nil {
+          throw SerializationError.invalid(task: name, field: "dependency \(dependency)")
+        }
+        
+        try buildTask(
+          name: dependency,
+          data: jsonData[dependency]!,
+          tasks: &tasks,
+          dependedOnBy: newDependedOnBy
+        )
+        
+        dependencies.insert(tasks[dependency]!)
+      }
+      
+      // The current task is finally built once all of its dependencies have been too.
+      tasks[name] = Task(id: id,
+                         release: release,
+                         deadline: deadline,
+                         wcet: wcet,
+                         dependencies: dependencies)
+    }
+        
+    var tasks: [String: Task] = [:]
+    for (taskName, data) in jsonData {
+      try buildTask(name: taskName, data: data, tasks: &tasks)
+    }
+    
+    self.init(tasks: Set<Task>(tasks.values))
+  }
+  
+}

--- a/Sources/SchedulabilityLib/TaskModel+JSON.swift
+++ b/Sources/SchedulabilityLib/TaskModel+JSON.swift
@@ -1,23 +1,15 @@
 import Foundation
 
-struct RuntimeError: Error, CustomStringConvertible {
-  var description: String
-  
-  init(_ description: String) {
-    self.description = description
-  }
-}
-
 /// An error thrown when the JSON data used to initialize a TaskModel is invalid, incomplete, or
 /// contains a circular dependency between tasks.
-enum SerializationError: Error, CustomStringConvertible {
+public enum SerializationError: Error, CustomStringConvertible, Equatable {
 
   case invalidConfiguration
   case missing(task: String, field: String)
   case invalid(task: String, field: String)
   case circularDependency(task1: String, task2: String)
   
-  var description: String {
+  public var description: String {
     switch self {
     case .invalidConfiguration:
       return "Input configuration file does not follow a valid format"
@@ -36,16 +28,10 @@ extension TaskModel {
   
   /// Initialize a task model from a JSON configuration file.
   ///
-  /// - Parameter json: The path to a JSON file containing a desciption of the task model to
-  ///     initialize.
-  public init(from json: String) throws {
-    // Throw a runtime error if the input JSON file cannot be read.
-    guard let input = try? Data(contentsOf: URL(fileURLWithPath: json), options: []) else {
-      throw RuntimeError("Couldn't read from '\(json)'!")
-    }
-    
-    // Read the configuration file as a dictionary.
-    guard let jsonData = try JSONSerialization.jsonObject(with: input, options: [])
+  /// - Parameter json: JSON data describing the configuration of the task model to initialize.
+  public init(from json: Data) throws {
+    // Read the configuration JSON as a dictionary.
+    guard let jsonData = try JSONSerialization.jsonObject(with: json, options: [])
       as? [String: [String: Any]] else {
         throw SerializationError.invalidConfiguration
     }

--- a/Sources/schedulability/main.swift
+++ b/Sources/schedulability/main.swift
@@ -1,42 +1,48 @@
+import ArgumentParser
 import SchedulabilityLib
 
-func print(scheduling: [ScheduleKey : ScheduleValue]) {
-  let tasks = scheduling.keys.filter({ $0.isTaskID })
+struct SchedulabilityCommand: ParsableCommand {
+  
+  @Argument(default: nil, help: "The path to a configuration file describing a task model")
+  var configurationFile: String
+  
+  /// Pretty print a scheduling.
+  private func pprint(scheduling: [ScheduleKey : ScheduleValue]) {
+    let tasks = scheduling.keys.filter({ $0.isTaskID })
 
-  // Print the current clock of each core.
-  for coreKey in scheduling.keys.filter({ $0.isCoreID }).sorted() {
-    print("\(coreKey) @ \(scheduling[coreKey]!.clock): ", terminator: "")
+    // Print the current clock of each core.
+    for coreKey in scheduling.keys.filter({ $0.isCoreID }).sorted() {
+      print("\(coreKey) @ \(scheduling[coreKey]!.clock): ", terminator: "")
 
-    // Identify the tasks that are scheduled on the current core and order them according to the
-    // scheduled execution order.
-    let coreTasks = tasks.filter({ scheduling[$0]?.coreID == coreKey.coreID })
-      .sorted(by: { a, b in
-        scheduling[a]!.clock < scheduling[b]!.clock
-      })
+      // Identify the tasks that are scheduled on the current core and order them according to the
+      // scheduled execution order.
+      let coreTasks = tasks.filter({ scheduling[$0]?.coreID == coreKey.coreID })
+        .sorted(by: { a, b in
+          scheduling[a]!.clock < scheduling[b]!.clock
+        })
 
-    print(coreTasks.map({ "t\($0.taskID):\(scheduling[$0]!.clock)" }).joined(separator: ", "))
+      print(coreTasks.map({ "t\($0.taskID):\(scheduling[$0]!.clock)" }).joined(separator: ", "))
+    }
   }
+  
+  func run() throws {
+    let factory = ScheduleSet.Factory()
+    let model = try TaskModel(from: configurationFile)
+    
+    let schedulings = model.schedulings(coreCount: 2, with: factory)
+    print("Number of possible schedulings: \(schedulings.count)")
+    print("Number of nodes created: \(factory.createdCount)\n")
+
+    //print(schedulings.randomElement() as Any)
+    //if let scheduling = schedulings.randomElement() {
+    //  print(scheduling: scheduling)
+    //}
+    for scheduling in schedulings {
+      pprint(scheduling: scheduling)
+      print()
+    }
+  }
+  
 }
 
-let factory = ScheduleSet.Factory()
-
-let model = TaskModel {
-  let t2 = Task(id: 2, release: 1, wcet: 1)
-  let t1 = Task(id: 1, wcet: 3)
-  let t0 = Task(id: 0, deadline: 4, wcet: 2, dependencies: [t2])
-
-  return [t0, t1, t2]
-}
-
-let schedulings = model.schedulings(coreCount: 2, with: factory)
-print("Number of possible schedulings: \(schedulings.count)")
-print("Number of nodes created: \(factory.createdCount)\n")
-
-//print(schedulings.randomElement() as Any)
-//if let scheduling = schedulings.randomElement() {
-//  print(scheduling: scheduling)
-//}
-for scheduling in schedulings {
-  print(scheduling: scheduling)
-  print()
-}
+SchedulabilityCommand.main()

--- a/Tests/SchedulabilityLibTests/TaskModel+JSONTests.swift
+++ b/Tests/SchedulabilityLibTests/TaskModel+JSONTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+
+@testable import SchedulabilityLib
+
+final class TaskModelJSONTests: XCTestCase {
+  
+  func testInitTaskModelWithJSON() {
+    let json = """
+    {
+      "t0": {
+        "id": 0,
+        "wcet": 2,
+        "dependencies": ["t2", "t3"]
+      },
+      
+      "t1": {
+        "id": 1,
+        "wcet": 3,
+        "deadline": 4,
+        "dependencies": ["t3"]
+      },
+      
+      "t2": {
+        "id": 2,
+        "wcet": 1,
+        "release": 1
+      },
+      
+      "t3": {
+        "id": 3,
+        "wcet": 1
+      }
+    }
+    """.data(using: .utf8)
+    
+    let taskModel = try? TaskModel(from: json!)
+    
+    XCTAssertNotNil(taskModel)
+    
+    let task0 = taskModel?.tasks[0]
+    XCTAssertNotNil(task0)
+    XCTAssertEqual(task0?.id, 0)
+    XCTAssertEqual(task0?.wcet, 2)
+    XCTAssertEqual(task0?.dependencies.count, 2)
+    
+    let task1 = taskModel?.tasks[1]
+    XCTAssertNotNil(task1)
+    XCTAssertEqual(task1?.id, 1)
+    XCTAssertEqual(task1?.wcet, 3)
+    XCTAssertEqual(task1?.deadline, 4)
+    XCTAssertEqual(task1?.dependencies.count, 1)
+    
+    let task2 = taskModel?.tasks[2]
+    XCTAssertNotNil(task2)
+    XCTAssertEqual(task2?.id, 2)
+    XCTAssertEqual(task2?.wcet, 1)
+    XCTAssertEqual(task2?.release, 1)
+    
+    let task3 = taskModel?.tasks[3]
+    XCTAssertNotNil(task3)
+    XCTAssertEqual(task3?.id, 3)
+    XCTAssertEqual(task3?.wcet, 1)
+  }
+  
+  func testInvalidConfiguration() {
+    let json = """
+    {
+      "t0": [
+        {"id": 0}
+      ]
+    }
+    """.data(using: .utf8)
+    
+    XCTAssertThrowsError(try TaskModel(from: json!)) { error in
+      XCTAssertEqual(error as! SerializationError, SerializationError.invalidConfiguration)
+    }
+  }
+  
+  func testMissingField() {
+    let json = """
+    {
+      "t0": {
+        "wcet": 1
+      }
+    }
+    """.data(using: .utf8)
+    
+    XCTAssertThrowsError(try TaskModel(from: json!)) { error in
+      XCTAssertEqual(error as! SerializationError,
+                     SerializationError.missing(task: "t0", field: "id"))
+    }
+  }
+  
+  func testInvalidField() {
+    let json = """
+    {
+      "t0": {
+        "id": 0,
+        "wcet": 1,
+        "dependencies": ["t2"]
+      },
+
+      "t1": {
+        "id": 1,
+        "wcet": 1
+      }
+    }
+    """.data(using: .utf8)
+    
+    XCTAssertThrowsError(try TaskModel(from: json!)) { error in
+      XCTAssertEqual(error as! SerializationError,
+                     SerializationError.invalid(task: "t0", field: "dependency t2"))
+    }
+  }
+  
+  func testCircularDepencency() {
+    let json = """
+    {
+      "t0": {
+        "id": 0,
+        "wcet": 1,
+        "dependencies": ["t1"]
+      },
+
+      "t1": {
+        "id": 1,
+        "wcet": 1,
+        "dependencies": ["t0"]
+      }
+    }
+    """.data(using: .utf8)
+    
+    XCTAssertThrowsError(try TaskModel(from: json!)) { error in
+      let serializationError = error as! SerializationError
+      XCTAssert(
+        serializationError == SerializationError.circularDependency(task1: "t0", task2: "t1") ||
+        serializationError == SerializationError.circularDependency(task1: "t1", task2: "t0")
+      )
+    }
+  }
+  
+}


### PR DESCRIPTION
This pull request extends the TaskModel struct with an initializer taking json data as input. It also changes the main module to take a path to a json file as argument when calling the program from the command line.